### PR TITLE
Fix request header

### DIFF
--- a/client.go
+++ b/client.go
@@ -238,7 +238,7 @@ func (c *Client) do(method, path, contentType string, send []byte) (*http.Respon
 
 	// response accept gziped content.
 	req.Header.Add(acceptEncodingHeaderKey, gzipEncodingHeaderValue)
-	req.Header.Add(acceptHeaderKey, contentTypeSchemaJSON+"application/vnd.schemaregistry+json, application/json")
+	req.Header.Add(acceptHeaderKey, contentTypeSchemaJSON+", application/vnd.schemaregistry+json, application/json")
 
 	// send the request and check the response for any connection & authorization errors here.
 	resp, err := c.client.Do(req)


### PR DESCRIPTION
We recently pulled from master and noticed that we were getting 400s back from the schema registry.  After logging out the `req.Header` we noticed that it was formatted incorrectly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/schema-registry/13)
<!-- Reviewable:end -->
