### PR TITLE
Adding `get-config` to Retrieve Compatiblity-Level

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Available Commands:
   add         registers the schema provided through stdin
   exists      checks if the schema provided through stdin exists for the subject
   get         retrieves a schema specified by id or subject
+  get-config  retrieves global or suject specific configuration
   subjects    lists all registered subjects
   versions    lists all available versions
 

--- a/schema-registry-cli/cmd/get_config.go
+++ b/schema-registry-cli/cmd/get_config.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var getConfigCmd = &cobra.Command{
+	Use:   "get-config [subject]",
+	Short: "retrieves global or suject specific configuration",
+	Long: `Configuration can be requested for all or a specific subject. When "compatibility-level"
+is not defined for a specific subject, then it's using global compatibility level. To check global
+setting just call "get-config" without arguments.
+Compatibility levels in Schema-Registry may be: "NONE", "BACKWARD", "FORWARD" and "FULL". Please
+consider official documentation for more details.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch {
+		case len(args) > 1:
+			return fmt.Errorf("only one subject allowed")
+		case len(args) == 0:
+			if err := getConfig(""); err != nil {
+				return err
+			}
+		case len(args) == 1:
+			if err := getConfig(args[0]); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(getConfigCmd)
+}

--- a/schema-registry-cli/cmd/helpers.go
+++ b/schema-registry-cli/cmd/helpers.go
@@ -63,6 +63,26 @@ func getBySubjectVersion(subj string, ver int) error {
 	return nil
 }
 
+func printConfig(cfg schemaregistry.Config, subj string) {
+	if subj == "" {
+		subj = "global"
+	}
+	if cfg.CompatibilityLevel == "" {
+		cfg.CompatibilityLevel = "not defined, using global"
+	}
+	fmt.Printf("%s compatibility-level: %s\n", subj, cfg.CompatibilityLevel)
+}
+
+func getConfig(subj string) error {
+	cl := assertClient()
+	cfg, err := cl.GetConfig(subj)
+	if err != nil {
+		return err
+	}
+	printConfig(cfg, subj)
+	return nil
+}
+
 func assertClient() *schemaregistry.Client {
 	c, err := schemaregistry.NewClient(viper.GetString("url"))
 	if err != nil {


### PR DESCRIPTION
Including one more sub-command, `get-config` to retrieve global and subject specific compatibility-mode (Configuration).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/schema-registry/14)
<!-- Reviewable:end -->
