### PR TITLE
Add a command to test schema compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Usage:
 
 Available Commands:
   add         registers the schema provided through stdin
+  compatible  tests compatibility between a schema from stdin and a given subject
   exists      checks if the schema provided through stdin exists for the subject
   get         retrieves a schema specified by id or subject
   get-config  retrieves global or suject specific configuration

--- a/client.go
+++ b/client.go
@@ -449,6 +449,10 @@ type (
 		ID int `json:"id"`
 	}
 
+	isCompatibleJSON struct {
+		IsCompatible bool `json:"is_compatible"`
+	}
+
 	// Schema describes a schema, look `GetSchema` for more.
 	Schema struct {
 		// Schema is the Avro schema string.
@@ -621,4 +625,61 @@ func (c *Client) getConfigSubject(subject string) (Config, error) {
 // subject. When Config returned has "compatibilityLevel" empty, it's using global settings.
 func (c *Client) GetConfig(subject string) (Config, error) {
 	return c.getConfigSubject(subject)
+}
+
+// subject (string) – Name of the subject
+// version (versionId [string "latest" or 1,2^31-1]) – Version of the schema to be returned.
+// Valid values for versionId are between [1,2^31-1] or the string “latest”.
+// The string “latest” refers to the last registered schema under the specified subject.
+// Note that there may be a new latest schema that gets registered right after this request is served.
+//
+// It's not safe to use just an interface to the high-level API, therefore we split this method
+// to two, one which will retrieve the latest versioned schema and the other which will accept
+// the version as integer and it will retrieve by a specific version.
+//
+// See `IsSchemaCompatible` and `IsLatestSchemaCompatible` instead.
+func (c *Client) isSchemaCompatibleAtVersion(subject string, avroSchema string, versionID interface{}) (combatible bool, err error) {
+	if subject == "" {
+		err = errRequired("subject")
+		return
+	}
+	if avroSchema == "" {
+		err = errRequired("avroSchema")
+		return
+	}
+
+	if err = checkSchemaVersionID(versionID); err != nil {
+		return
+	}
+
+	schema := schemaOnlyJSON{
+		Schema: avroSchema,
+	}
+
+	send, err := json.Marshal(schema)
+	if err != nil {
+		return
+	}
+
+	// # Test input schema against a particular version of a subject’s schema for compatibility
+	// POST /compatibility/subjects/(string: subject)/versions/(versionId: "latest" | int)
+	path := fmt.Sprintf("compatibility/"+subjectPath+"/versions/%v", subject, versionID)
+	resp, err := c.do(http.MethodPost, path, contentTypeSchemaJSON, send)
+	if err != nil {
+		return
+	}
+
+	var res isCompatibleJSON
+	err = c.readJSON(resp, &res)
+	return res.IsCompatible, err
+}
+
+// IsSchemaCompatible tests compatibility with a specific version of a subject's schema.
+func (c *Client) IsSchemaCompatible(subject string, avroSchema string, versionID int) (bool, error) {
+	return c.isSchemaCompatibleAtVersion(subject, avroSchema, versionID)
+}
+
+// IsLatestSchemaCompatible tests compatibility with the latest version of a subject's schema.
+func (c *Client) IsLatestSchemaCompatible(subject string, avroSchema string) (bool, error) {
+	return c.isSchemaCompatibleAtVersion(subject, avroSchema, SchemaLatestVersion)
 }

--- a/schema-registry-cli/cmd/compatible.go
+++ b/schema-registry-cli/cmd/compatible.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+// compatible can handle two argument styles: <subj ver> or <subj>
+var compatibleCmd = &cobra.Command{
+	Use:   "compatible <subject> [version]",
+	Short: "tests compatibility between a schema from stdin and a given subject",
+	Long: `The compatibility level of the subject is used for this check.
+If it has never been changed, the global compatibility level applies.
+If no schema version is specified, the latest version is tested.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 || len(args) > 2 {
+			return fmt.Errorf("expected 1 to 2 arguments")
+		}
+		var iscompat bool
+		var err error
+		switch len(args) {
+		case 1:
+			iscompat, err = assertClient().IsLatestSchemaCompatible(args[0], stdinToString())
+		case 2:
+			ver, err := strconv.Atoi(args[1])
+			if err != nil {
+				return fmt.Errorf("2nd argument must be a version number")
+			}
+			iscompat, err = assertClient().IsSchemaCompatible(args[0], stdinToString(), ver)
+		}
+		if err != nil {
+			return err
+		}
+		if iscompat {
+			fmt.Println("the provided schema is compatible")
+		} else {
+			err = fmt.Errorf("the provided schema is not compatible")
+		}
+		return err
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(compatibleCmd)
+}


### PR DESCRIPTION
Addresses issue #4 with a `compatible` command 

Unfortunately the compatibility API doesn't provide much context on the failures involved, but this is still nice to have.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/schema-registry/15)
<!-- Reviewable:end -->
