### PR TITLE
Color output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Available Commands:
 
 Flags:
   -h, --help         help for schema-registry-cli
+  -n, --no-color     dont color output
   -e, --url string   schema registry url, overrides SCHEMA_REGISTRY_URL (default "http://localhost:8081")
   -v, --verbose      be verbose
 

--- a/schema-registry-cli/cmd/helpers.go
+++ b/schema-registry-cli/cmd/helpers.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -26,14 +25,12 @@ func printSchema(sch schemaregistry.Schema) {
 	log.Printf("version: %d\n", sch.Version)
 	log.Printf("id: %d\n", sch.ID)
 
-	var formatted bytes.Buffer
 	pretty, err := prettyjson.Format([]byte(sch.Schema))
 	if err != nil {
 		fmt.Println(sch.Schema) //isn't a json object, which is legal
 		return
 	}
-	formatted.Write(pretty)
-	formatted.WriteTo(os.Stdout)
+	os.Stdout.Write(pretty)
 	os.Stdout.WriteString("\n")
 }
 

--- a/schema-registry-cli/cmd/helpers.go
+++ b/schema-registry-cli/cmd/helpers.go
@@ -3,13 +3,14 @@ package cmd
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 
-	"github.com/landoop/schema-registry"
+	"github.com/hokaccha/go-prettyjson"
+
+	schemaregistry "github.com/landoop/schema-registry"
 	"github.com/spf13/viper"
 )
 
@@ -24,12 +25,15 @@ func stdinToString() string {
 func printSchema(sch schemaregistry.Schema) {
 	log.Printf("version: %d\n", sch.Version)
 	log.Printf("id: %d\n", sch.ID)
-	var indented bytes.Buffer
-	if err := json.Indent(&indented, []byte(sch.Schema), "", "  "); err != nil {
+
+	var formatted bytes.Buffer
+	pretty, err := prettyjson.Format([]byte(sch.Schema))
+	if err != nil {
 		fmt.Println(sch.Schema) //isn't a json object, which is legal
 		return
 	}
-	indented.WriteTo(os.Stdout)
+	formatted.Write(pretty)
+	formatted.WriteTo(os.Stdout)
 	os.Stdout.WriteString("\n")
 }
 

--- a/schema-registry-cli/cmd/root.go
+++ b/schema-registry-cli/cmd/root.go
@@ -6,7 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/landoop/schema-registry"
+	"github.com/fatih/color"
+	schemaregistry "github.com/landoop/schema-registry"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -16,6 +17,7 @@ var (
 	cfgFile     string
 	registryURL string
 	verbose     bool
+	nocolor     bool
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -26,6 +28,9 @@ var RootCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if !verbose {
 			log.SetOutput(ioutil.Discard)
+		}
+		if nocolor {
+			color.NoColor = true
 		}
 		log.Printf("schema registry url: %s\n", viper.Get("url"))
 	},
@@ -42,6 +47,7 @@ func Execute() {
 
 func init() {
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "be verbose")
+	RootCmd.PersistentFlags().BoolVarP(&nocolor, "no-color", "n", false, "dont color output")
 	RootCmd.PersistentFlags().StringVarP(&registryURL, "url", "e", schemaregistry.DefaultURL, "schema registry url, overrides SCHEMA_REGISTRY_URL")
 	viper.SetEnvPrefix("schema_registry")
 	viper.BindPFlag("url", RootCmd.PersistentFlags().Lookup("url"))


### PR DESCRIPTION
Found myself piping stuff to `jq` a lot to get pretty schemas and so I thought it could be useful if the cli tool could color output itself. Of course there is a flag to disable color output and it should be automatically disabled if not supported byt the Terminal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/schema-registry/16)
<!-- Reviewable:end -->
