### PR TITLE
Fix content type check in error handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -253,7 +253,7 @@ func (c *Client) do(method, path, contentType string, send []byte) (*http.Respon
 
 		if strings.Contains(respContentType, "text/html") {
 			// if the body is html, then don't read it, it doesn't contain the raw info we need.
-		} else if strings.Contains(respContentType, "application/json") {
+		} else if strings.Contains(respContentType, "json") {
 			// if it's json try to read it as confluent's specific error json.
 			var resErr ResourceError
 			c.readJSON(resp, &resErr)


### PR DESCRIPTION
I noticed that my schema registry reponds with a  content type of `application/vnd.schemaregistry.v1+json` and so the errors are not correctly interpreted as `schemaregistry.ResourceError`. This further causes the `IsSubjectNotFound` and `IsSchemaNotFound` checks to not work as expected.

According to the docs the Content-Type might be any of
- `application/vnd.schemaregistry.v1+json`
- `application/vnd.schemaregistry+json`
- `application/json`

So I figured checking for just `json` should work for any case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/schema-registry/17)
<!-- Reviewable:end -->
