### PR TITLE
Allow HTTP Client other than http.Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -39,16 +39,22 @@ type (
 )
 
 // UsingClient modifies the underline HTTP Client that schema registry is using for contact with the backend server.
-func UsingClient(httpClient *http.Client) Option {
+func UsingClient(httpClient httpDoer) Option {
 	return func(c *Client) {
 		if httpClient == nil {
 			return
 		}
 
-		transport := getTransportLayer(httpClient, 0)
-		httpClient.Transport = transport
-
 		c.client = httpClient
+
+		netHttpClient, ok := httpClient.(*http.Client)
+
+		if !ok {
+			return
+		}
+
+		transport := getTransportLayer(netHttpClient, 0)
+		netHttpClient.Transport = transport
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -78,6 +78,36 @@ func TestSubjects(t *testing.T) {
 	mustEqual(t, subs, subsIn)
 }
 
+func TestConfigWithGenericHTTPClient(t *testing.T) {
+	// Prime dummy handler with any successful request: we just want to see that it's called
+	// when passed to NewClient via UsingClient()
+	subsIn := []string{"rollulus", "hello-subject"}
+	d := dummyHTTPHandler(t, "GET", "/subjects", 200, nil, subsIn)
+	c, err := NewClient(testHost, UsingClient(d))
+	if err != nil {
+		t.Error(err)
+	}
+	subs, err := c.Subjects()
+	if err != nil {
+		t.Error(err)
+	}
+	mustEqual(t, subs, subsIn)
+}
+
+func TestNetHTTPClientTransportConfigured(t *testing.T) {
+	httpClient := &http.Client{}
+	c, err := NewClient(DefaultURL, UsingClient(httpClient))
+	if err != nil {
+		t.Error(err)
+	}
+	if c.client != httpClient {
+		t.Error()
+	}
+	if httpClient.Transport == nil {
+		t.Error()
+	}
+}
+
 func TestVersions(t *testing.T) {
 	versIn := []int{1, 2, 3}
 	c := httpSuccess(t, "GET", "/subjects/mysubject/versions", nil, versIn)


### PR DESCRIPTION
Use `httpDoer` contract as parameter of `UsingClient` so that the schema registry may use an implementation other than `http.Client`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/schema-registry/18)
<!-- Reviewable:end -->
