### PR TITLE
Support basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Available Commands:
   versions    lists all available versions
 
 Flags:
+  -p, --basic-auth-pass string   Password for basic auth, overrides SCHEMA_REGISTRY_BASIC_AUTH_PASS
+  -u, --basic-auth-user string   User for basic auth, overrides SCHEMA_REGISTRY_BASIC_AUTH_USER
   -h, --help         help for schema-registry-cli
   -n, --no-color     dont color output
   -e, --url string   schema registry url, overrides SCHEMA_REGISTRY_URL (default "http://localhost:8081")

--- a/schema-registry-cli/cmd/basic_auth_client.go
+++ b/schema-registry-cli/cmd/basic_auth_client.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"net/http"
+)
+
+type BasicAuthCredential struct {
+	Username string
+	Password string
+	transport http.RoundTripper
+}
+
+func (c BasicAuthCredential) GetClient() *http.Client {
+	if c.transport == nil {
+		c.transport = http.DefaultTransport
+	}
+
+	return &http.Client{ Transport: c }
+}
+
+func (c BasicAuthCredential) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.SetBasicAuth(c.Username, c.Password)
+
+	return c.transport.RoundTrip(r)
+}

--- a/schema-registry-cli/cmd/helpers.go
+++ b/schema-registry-cli/cmd/helpers.go
@@ -85,7 +85,18 @@ func getConfig(subj string) error {
 }
 
 func assertClient() *schemaregistry.Client {
-	c, err := schemaregistry.NewClient(viper.GetString("url"))
+	var c *schemaregistry.Client
+	var err error
+	if viper.GetString("basic_auth_user") != "" && viper.GetString("basic_auth_pass") != "" {
+		// Use Basic Authentication
+		b := &BasicAuthCredential{
+			Username: viper.GetString("basic_auth_user"),
+			Password: viper.GetString("basic_auth_pass"),
+		}
+		c, err = schemaregistry.NewClient(viper.GetString("url"), schemaregistry.UsingClient(b.GetClient()))
+	} else {
+		c, err = schemaregistry.NewClient(viper.GetString("url"))
+	}
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(-1)

--- a/schema-registry-cli/cmd/root.go
+++ b/schema-registry-cli/cmd/root.go
@@ -14,10 +14,12 @@ import (
 )
 
 var (
-	cfgFile     string
-	registryURL string
-	verbose     bool
-	nocolor     bool
+	cfgFile       string
+	registryURL   string
+	basicAuthUser string
+	basicAuthPass string
+	verbose       bool
+	nocolor       bool
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -49,7 +51,13 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "be verbose")
 	RootCmd.PersistentFlags().BoolVarP(&nocolor, "no-color", "n", false, "dont color output")
 	RootCmd.PersistentFlags().StringVarP(&registryURL, "url", "e", schemaregistry.DefaultURL, "schema registry url, overrides SCHEMA_REGISTRY_URL")
+	RootCmd.PersistentFlags().StringVarP(&basicAuthUser, "basic-auth-user", "u", "", "User for basic auth, overrides SCHEMA_REGISTRY_BASIC_AUTH_USER")
+	RootCmd.PersistentFlags().StringVarP(&basicAuthPass, "basic-auth-pass", "p", "", "Password for basic auth, overrides SCHEMA_REGISTRY_BASIC_AUTH_PASS")
 	viper.SetEnvPrefix("schema_registry")
 	viper.BindPFlag("url", RootCmd.PersistentFlags().Lookup("url"))
 	viper.BindEnv("url")
+	viper.BindPFlag("basic_auth_user", RootCmd.PersistentFlags().Lookup("basic-auth-user"))
+	viper.BindEnv("basic_auth_user")
+	viper.BindPFlag("basic_auth_pass", RootCmd.PersistentFlags().Lookup("basic-auth-pass"))
+	viper.BindEnv("basic_auth_pass")
 }


### PR DESCRIPTION
Schema Registry in Confluent Cloud (currently in [Preview](https://docs.confluent.io/current/cloud/limits.html#sr-prv)) requires Basic Authentication, but current version of `schema-registry-cli` doesn't support it.

This PR adds a basic authentication support and it takes its access credential from the two options `--basic-auth-user` and `--basic-auth-pass`, or environment variables `SCHEMA_REGISTRY_BASIC_AUTH_USER` and `SCHEMA_REGISTRY_BASIC_AUTH_PASS`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/schema-registry/19)
<!-- Reviewable:end -->
