### PR TITLE
Add 'delete' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Usage:
 Available Commands:
   add         registers the schema provided through stdin
   compatible  tests compatibility between a schema from stdin and a given subject
+  delete      delete a subject
   exists      checks if the schema provided through stdin exists for the subject
   get         retrieves a schema specified by id or subject
   get-config  retrieves global or suject specific configuration

--- a/schema-registry-cli/cmd/delete.go
+++ b/schema-registry-cli/cmd/delete.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/manifoldco/promptui"
+)
+
+// get can handle three argument styles: <id>, <subj ver> or <subj>
+var deleteCmd = &cobra.Command{
+	Use:   "delete <subject>",
+	Short: "delete a subject",
+	Long:``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("expected 1 argument")
+		}
+
+		subject := args[0]
+
+		prompt := promptui.Prompt{
+			Label: fmt.Sprintf("Warning! You are deleting the subject '%s'. Are you sure", subject),
+			IsConfirm: true,
+		}
+
+		_, err := prompt.Run()
+		if err != nil {
+			fmt.Printf("Aborted.\n")
+			return nil
+		}
+
+		err = deleteSubject(subject)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("'%s' has been deleted\n", subject)
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(deleteCmd)
+}

--- a/schema-registry-cli/cmd/helpers.go
+++ b/schema-registry-cli/cmd/helpers.go
@@ -84,6 +84,15 @@ func getConfig(subj string) error {
 	return nil
 }
 
+func deleteSubject(subj string) error {
+	cl := assertClient()
+	_, err := cl.DeleteSubject(subj)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func assertClient() *schemaregistry.Client {
 	c, err := schemaregistry.NewClient(viper.GetString("url"))
 	if err != nil {


### PR DESCRIPTION
This PR adds `delete` command to `schema-registory-cli`.
In order to prevent the accidental deletion, it shows the confirmation prompt before calling the delete endpoint.

\[Note\] In order to show the confirmation prompt, this PR adds a new dependency [promptui](https://github.com/manifoldco/promptui)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/schema-registry/20)
<!-- Reviewable:end -->
