### PR TITLE
Add basic auth to schema registry

### DIFF
--- a/schema-registry-cli/cmd/helpers.go
+++ b/schema-registry-cli/cmd/helpers.go
@@ -90,5 +90,15 @@ func assertClient() *schemaregistry.Client {
 		fmt.Println(err)
 		os.Exit(-1)
 	}
+	username := viper.GetString("username")
+	password := viper.GetString("password")
+
+	if username != "" && password != "" {
+		err = c.SetBasicAuth(username, password)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(-1)
+		}
+	}
 	return c
 }

--- a/schema-registry-cli/cmd/root.go
+++ b/schema-registry-cli/cmd/root.go
@@ -28,11 +28,16 @@ var RootCmd = &cobra.Command{
 	Short: "A command line interface for the Confluent schema registry",
 	Long:  `A command line interface for the Confluent schema registry`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		flags := cmd.Flags()
 		if !verbose {
 			log.SetOutput(ioutil.Discard)
 		}
 		if nocolor {
 			color.NoColor = true
+		}
+		if flags.Changed("username") != flags.Changed("password") {
+			fmt.Println("[Err] Both 'username' and 'password' flags must be set to enable basic authentication")
+			os.Exit(-1)
 		}
 		log.Printf("schema registry url: %s\n", viper.Get("url"))
 	},

--- a/schema-registry-cli/cmd/root.go
+++ b/schema-registry-cli/cmd/root.go
@@ -16,6 +16,8 @@ import (
 var (
 	cfgFile     string
 	registryURL string
+	username    string
+	password    string
 	verbose     bool
 	nocolor     bool
 )
@@ -49,7 +51,13 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "be verbose")
 	RootCmd.PersistentFlags().BoolVarP(&nocolor, "no-color", "n", false, "dont color output")
 	RootCmd.PersistentFlags().StringVarP(&registryURL, "url", "e", schemaregistry.DefaultURL, "schema registry url, overrides SCHEMA_REGISTRY_URL")
+	RootCmd.PersistentFlags().StringVarP(&username, "username", "u", "", "schema registy basic auth username, overrides SCHEMA_REGISTRY_USERNAME")
+	RootCmd.PersistentFlags().StringVarP(&password, "password", "p", "", "schema registry basic auth password, overrides SCHEMA_REGISTRY_PASSWORD")
 	viper.SetEnvPrefix("schema_registry")
 	viper.BindPFlag("url", RootCmd.PersistentFlags().Lookup("url"))
 	viper.BindEnv("url")
+	viper.BindPFlag("username", RootCmd.PersistentFlags().Lookup("username"))
+	viper.BindEnv("username")
+	viper.BindPFlag("password", RootCmd.PersistentFlags().Lookup("password"))
+	viper.BindEnv("password")
 }


### PR DESCRIPTION
This PR enables basic authentication for schema registry by the means of adding two new parameters to the root cli command:
- `--username`, `-u`: basic authentication user
- `--password`, `-p`: basic authentication password

Basic auth itself is implemented in a way to make it easy to support different kind of authentications based on the `Authorization` header, should they be supported in the future or by custom 3rd party implementations.

